### PR TITLE
New Segment3d

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,25 @@ This project is a 3d-rendering engine made from scratch in C++ **without using a
 ![demo.gif](game_snapshots/demo.gif)
 
 
-### Work with this repository
+## Work with this repository
 
 :warning: Because I just created this repository the project is still not well commented, come back soon!
 
-##### Clone the repository
+### Clone the repository
 
 To clone this repository on your local computer please run:
 ```bash
 $ git clone https://github.com/PierreGuilmin/3D-engine.git
 ```
 
-##### Install SFML
+### Install SFML
 This project was written in **C++** (C++11). It uses the open-source library [SFML](https://www.sfml-dev.org/index.php) (SFML 2.5.0) which is a cross-platform library written in C++ to open windows, draw 2d lines/images, handle the keyboard and the mouse... The easiest way to install it on macOS is by using the (famous) 🍺[Homebrew](https://brew.sh) package manager:
 ```bash
 $ brew install sfml
 ```
 Otherwise for Windows user the library can be compiled from source on the SFML website under the [Download](https://www.sfml-dev.org/download/sfml/2.5.0/index.php) section.
 
-##### Compile the project
+### Compile the project
 The default compiler used in the makefile is `clang++`. Running the following command in the project folder will compile the sources and create an executable called **3D-engine**:
 ```bash
 $ make
@@ -49,8 +49,31 @@ CXX      = g++
 CXXFLAGS = -Wall -Wno-c++11-extensions
 ```
 
+### Emoji commit code table
 
-### Another 3d engine?!
+Please use the following table to commit code:
+
+| emoji        | meaning                      | code           |
+| :----------: | :--------------------------- | :------------- |
+| :sos:        | critical bug                 | `:sos:`        |
+| :warning:    | bug                          | `:warning:`    |
+| :eyes:       | to check                     | `:eyes:`       |
+| :flashlight: | simplification/clarification | `:flashlight:` |
+| :clipboard:  | comment                      | `:clipboard:`  |
+| :sparkles:   | typos & style                | `:sparkles:`   |
+| :tada:       | new feature                  | `:tada:`       |
+| :cloud:      | minor modification           | `:cloud:`      |
+
+For example if you want to commit a new rocket feature — `🎉 new feature, flying rocket!` — please do:
+```diff
+# bad syntax
+- $ git commit -m 'new feature, flying rocket!'
+
+# good syntax
++ $ git commit -m ':tada: new feature, flying rocket!'
+```
+
+## Another 3d engine?!
 
 This is a project I did on my own during my free time because I was curious about 3d rendering and wanted to practice C++. The goal was to render 3d objects on my screen without using any 3d libraries like OpenGL, doing every projections from the 3d space to the 2d screen on my own, as well as handling the camera rotation and objects movements. The only library used is the 2d library [SFML](https://www.sfml-dev.org/index.php).
 
@@ -58,15 +81,15 @@ See under a view of the basic scene proposed in `main.cpp` (the application is o
 ![basic_scene.png](game_snapshots/basic_scene.png)
 
 
-### The commands
+## The commands
 
 The commands to move in the 3d space are really intuitive and shouln't cause any trouble:
 * Move your mouse to see around
-* Use `W` (front), `A` (left), `S` (back), `D` (right) to move (front and back are going in the direction where your mouse points)
-* Use `Q` (up), `E` (down) to move along the third axis
+* Use `Z` (front), `Q` (left), `S` (back), `D` (right) to move (front and back are going in the direction where your mouse points)
+* Use `A` (up), `E` (down) to move along the third axis
 
 
-### The code architecture
+## The code architecture
 **`/src/utils`**  
 Implement basic helpers class and functions:
 * `mouse.hpp` and `mouse.cpp`: facilitate the access to the mouse last movement

--- a/src/asteroids_field.cpp
+++ b/src/asteroids_field.cpp
@@ -12,7 +12,7 @@ AsteroidsField::AsteroidsField(const Vector3d &center,
         asteroids.push_back(Asteroid3d(center + offset, rand(10, 50), 2));
 
         rotation_axes.push_back(Vector3d(rand(0.0, 1.0), rand(0.0, 1.0), rand(0.0, 1.0)));
-        rotation_speeds.push_back(rand(1, 5));
+        rotation_speeds.push_back(rand(-5.0, 5.0));
     }
 }
 

--- a/src/asteroids_field.hpp
+++ b/src/asteroids_field.hpp
@@ -9,7 +9,7 @@ class AsteroidsField {
 private:
     std::vector<Asteroid3d> asteroids;
     std::vector<Vector3d> rotation_axes;
-    std::vector<unsigned> rotation_speeds;
+    std::vector<double> rotation_speeds;
 
 public:
     // constructors

--- a/src/geometry/camera3d.cpp
+++ b/src/geometry/camera3d.cpp
@@ -97,7 +97,3 @@ Vector3d Camera3d::transform_vector(const Vector3d &v) const {
 					 sx * (cy * z + sy * (sz * y + cz * x)) + cx * (cz * y - sz * x),
 					 cx * (cy * z + sy * (sz * y + cz * x)) - sx * (cz * y - sz * x), v.color));
 }
-
-Segment3d Camera3d::transform_segment(const Segment3d &s) const {
- 	return Segment3d(transform_vector(s.a), transform_vector(s.b));
-}

--- a/src/geometry/camera3d.hpp
+++ b/src/geometry/camera3d.hpp
@@ -37,7 +37,6 @@ public:
 	void rotate(const double mouse_move_x, const double mouse_move_y);
 	void move(const DIRECTION direction);
 	Vector3d transform_vector(const Vector3d &v) const;
-	Segment3d transform_segment(const Segment3d &s) const;
 
 
 friend class Solid3d;

--- a/src/geometry/geometry.cpp
+++ b/src/geometry/geometry.cpp
@@ -5,25 +5,25 @@
 // ##############################################
 
 Cube3d::Cube3d(const Vector3d &_center, const double size) : Solid3d() {
-    Vector3d points[8];
+    Vector3d base_point = Vector3d(-size / 2, -size / 2, -size / 2);
 
     // front
-    points[0] = Vector3d(-size / 2, -size / 2, -size / 2);
-    points[1] = points[0] + Vector3d(size, 0   , 0);
-    points[2] = points[0] + Vector3d(size, size, 0);
-    points[3] = points[0] + Vector3d(0   , size, 0);
+    add_point(base_point);
+    add_point(base_point + Vector3d(size, 0   , 0));
+    add_point(base_point + Vector3d(size, size, 0));
+    add_point(base_point + Vector3d(0   , size, 0));
 
     // back
-    for (int i = 4; i < 8; ++i)
-        points[i] = points [i - 4] + Vector3d(0, 0, size);
+    for (auto p : points)
+        add_point(p + Vector3d(0, 0, size));
 
-    for (int i = 0; i < 8; ++i)
-        points[i].set_color(get_random_colour());
+    for (auto &p : points)
+        p.set_color(get_random_colour());
 
     for (int i = 0; i < 4; ++i) {
-        add_segment(Segment3d(points[i], points[(i + 1) % 4]));         // front face
-        add_segment(Segment3d(points[i + 4], points[(i + 1) % 4 + 4])); // back face
-        add_segment(Segment3d(points[i], points[i + 4]));               // links
+        add_segment(i    , (i + 1) % 4);     // front face
+        add_segment(i + 4, (i + 1) % 4 + 4); // back face
+        add_segment(i    , i + 4);           // links
     }
 
     *this += _center;
@@ -43,7 +43,8 @@ Ellipsoid3d::Ellipsoid3d(const Vector3d &_center,
                          const bool add_latitude_segments,
                          const bool add_longitude_segments) : Solid3d(),
                                                               nb_circles(_nb_circles),
-                                                              nb_points_per_circle(_nb_points_per_circle) {
+                                                              nb_points_per_circle(_nb_points_per_circle)
+                                                              {
 
     for (int i = 0; i < nb_circles; ++i) {
         double theta = map(i, 0, nb_circles - 1, -88, 88);
@@ -51,9 +52,9 @@ Ellipsoid3d::Ellipsoid3d(const Vector3d &_center,
         for (int j = 0; j < nb_points_per_circle; ++j) {
             double phi = map(j, 0, nb_points_per_circle, -180, 180);
 
-            points.push_back(Vector3d(a * cos(as_radians(theta)) * cos(as_radians(phi)),
-                                      b * cos(as_radians(theta)) * sin(as_radians(phi)),
-                                      c * sin(as_radians(theta))));
+            add_point(Vector3d(a * cos(as_radians(theta)) * cos(as_radians(phi)),
+                               b * cos(as_radians(theta)) * sin(as_radians(phi)),
+                               c * sin(as_radians(theta))));
         }
     }
 
@@ -69,21 +70,21 @@ void Ellipsoid3d::_add_segments(const bool add_latitude_segments, const bool add
         for (int j = 0; j < nb_points_per_circle; ++j) {
 
             if (add_latitude_segments)
-                add_segment(Segment3d(_point_at(i, j),  _point_at(i, j - 1)));
+                add_segment(_index_point_at(i, j), _index_point_at(i, j - 1));
 
             if (add_longitude_segments && i > 0)
-                add_segment(Segment3d(_point_at(i, j), _point_at(i - 1, j)));
+                add_segment(_index_point_at(i, j), _index_point_at(i - 1, j));
         }
     }
 }
 
-Vector3d& Ellipsoid3d::_point_at(const size_t circle_idx, const size_t point_idx) {
-    return points[mod(circle_idx, nb_circles) * nb_points_per_circle + mod(point_idx, nb_points_per_circle)];
+size_t Ellipsoid3d::_index_point_at(const size_t circle_idx, const size_t point_idx) {
+    return mod(circle_idx, nb_circles) * nb_points_per_circle + mod(point_idx, nb_points_per_circle);
 }
 
-// ##############################################
-// ### Asteroid3d ###############################
-// ##############################################
+// // ##############################################
+// // ### Asteroid3d ###############################
+// // ##############################################
 
 Asteroid3d::Asteroid3d(const Vector3d &_center,
                        const double size,
@@ -97,9 +98,9 @@ Asteroid3d::Asteroid3d(const Vector3d &_center,
     for (int i = 0; i < nb_circles; ++i) {
         for (int j = 0; j < nb_points_per_circle; ++j) {
 
-            _point_at(i, j).set_color(get_random_colour(110, 160,
-                                                        60, 110,
-                                                        20, 80));
+            points[_index_point_at(i, j)].set_color(get_random_colour(110, 160,
+                                                                      60, 110,
+                                                                      20, 80));
 
             if (i > 4 && i < nb_circles - 4 && rand(0, asteroid_complexity) == 0) {
 
@@ -111,9 +112,8 @@ Asteroid3d::Asteroid3d(const Vector3d &_center,
                         const double factor = 1.0 + map_gaussian_2d(k, -radius, radius,
                                                                     l, -sub_radius, sub_radius,
                                                                     amplitude);
-                        if (i + l >= 0 && i + l < nb_circles) {
-                            _point_at(i + l, j + k)  *= factor;
-                        }
+                        if (i + l >= 0 && i + l < nb_circles)
+                            points[_index_point_at(i + l, j + k)] *= factor;
                     }
                 }
             }
@@ -126,4 +126,3 @@ Asteroid3d::Asteroid3d(const Vector3d &_center,
 
     get_max_size();
 }
-

--- a/src/geometry/geometry.cpp
+++ b/src/geometry/geometry.cpp
@@ -82,9 +82,9 @@ size_t Ellipsoid3d::_index_point_at(const size_t circle_idx, const size_t point_
     return mod(circle_idx, nb_circles) * nb_points_per_circle + mod(point_idx, nb_points_per_circle);
 }
 
-// // ##############################################
-// // ### Asteroid3d ###############################
-// // ##############################################
+// ##############################################
+// ### Asteroid3d ###############################
+// ##############################################
 
 Asteroid3d::Asteroid3d(const Vector3d &_center,
                        const double size,

--- a/src/geometry/geometry.hpp
+++ b/src/geometry/geometry.hpp
@@ -22,7 +22,6 @@ public:
 // ##############################################
 class Ellipsoid3d : public Solid3d {
 protected:
-    std::vector<Vector3d> points;
     int nb_circles, nb_points_per_circle;
 
 public:
@@ -35,7 +34,7 @@ public:
 
 protected:
     void _add_segments(const bool add_latitude_segments, const bool add_longitude_segments);
-    Vector3d& _point_at(const size_t circle_idx, const size_t point_idx);
+    size_t _index_point_at(const size_t circle_idx, const size_t point_idx);
 };
 
 

--- a/src/geometry/plane3d.cpp
+++ b/src/geometry/plane3d.cpp
@@ -8,6 +8,7 @@ Plane3d& Plane3d::operator=(const Plane3d &p) {
     if (this != &p) {
         base   = p.base;
         normal = p.normal;
+        d      = p.d;
     }
 
     return *this;
@@ -18,13 +19,6 @@ Plane3d& Plane3d::operator=(const Plane3d &p) {
 // ### others ###################################
 // ##############################################
 
-// p(x, y, z) in plane [n(a, b, c), b] ⟺ n . (p - b)        = 0
-//                                     ⟺ n.p - n.b          = 0
-//                                     ⟺ ax + by + cz - n.b = 0 ⟹ d = - n.b
-double Plane3d::get_equation_coefficient_d() const {
-    return - (normal * base);
-}
-
 // v(x, y, z) point and p plane [n, b] with n unit vector, v2 normal intersection of v with p, distance:
 // D = | n . (v - v2) |
 //   = | n.v - n.v2 |
@@ -34,35 +28,35 @@ double Plane3d::get_equation_coefficient_d() const {
 //    - the distance D
 //    - the sign being > 0 if the point is "above the normal side", < 0 if "under the normal side"
 double Plane3d::get_signed_distance_from_point_to_plane(const Vector3d &v) const {
-    return v * normal + get_equation_coefficient_d() / normal.norm();
+    return v * normal + d / normal.norm();
 }
 
 // #TODO: missing comment
-bool Plane3d::handle_intersection_of_segment_with_plane(Segment3d &s) const {
-    const double da = get_signed_distance_from_point_to_plane(s.a);
-    const double db = get_signed_distance_from_point_to_plane(s.b);
+bool Plane3d::handle_intersection_of_segment_with_plane(Vector3d &a, Vector3d &b) const {
+    const double da = get_signed_distance_from_point_to_plane(a);
+    const double db = get_signed_distance_from_point_to_plane(b);
 
     if (da < 0 && db < 0)
         return true;
     else if (da > 0 & db < 0) {
         double f = da / (da - db); // intersection factor (between 0 and 1)
-        sf::Color new_color = sf::Color(s.a.color.r + f * (s.b.color.r - s.a.color.r),
-                                        s.a.color.g + f * (s.b.color.g - s.a.color.g),
-                                        s.a.color.b + f * (s.b.color.b - s.a.color.b));
-        s.b = s.a + (s.b - s.a) * f;
+        sf::Color new_color = sf::Color(a.color.r + f * (b.color.r - a.color.r),
+                                        a.color.g + f * (b.color.g - a.color.g),
+                                        a.color.b + f * (b.color.b - a.color.b));
+        b = a + (b - a) * f;
 
-        s.b.color = new_color;
+        b.color = new_color;
     }
-    else if (da < 0 & db > 0) {
-        std::swap(s.a, s.b);
-        handle_intersection_of_segment_with_plane(s);
-    }
+    else if (da < 0 & db > 0)
+        handle_intersection_of_segment_with_plane(b, a);
 
     return false;
 }
 
 // #TODO: explain change point opacity
-sf::Vertex Plane3d::get_projection_on_plane(const Vector3d &v, const unsigned window_width, const unsigned window_height) const {
+sf::Vertex Plane3d::get_projection_on_plane(const Vector3d &v,
+                                            const unsigned window_width,
+                                            const unsigned window_height) const {
     sf::Color vertex_color = v.color;
 
     vertex_color.a = map(get_signed_distance_from_point_to_plane(v), 0, PROJECTION_MAX_DEPTH, 255, 0); 

--- a/src/geometry/plane3d.hpp
+++ b/src/geometry/plane3d.hpp
@@ -11,21 +11,30 @@ class Plane3d {
 private:
     Vector3d base;
     Vector3d normal;
+
+    // p(x, y, z) in plane [n(a, b, c), b] ⟺ n . (p - b)        = 0
+    //                                     ⟺ n.p - n.b          = 0
+    //                                     ⟺ ax + by + cz - n.b = 0 ⟹ d = - n.b
+    double d;
     
 public:
     // constructors
-    Plane3d() : base(Vector3d()), normal(Vector3d()) {}
-    Plane3d(const Vector3d &_base, const Vector3d &_normal) : base(_base), normal(_normal) {}
-    Plane3d(const Plane3d &p) : base(p.base), normal(p.normal) {}
+    Plane3d() : base(Vector3d()), normal(Vector3d()), d(0.0) {}
+    Plane3d(const Vector3d &_base,
+            const Vector3d &_normal) : base(_base),
+                                       normal(_normal),
+                                       d(- (_normal * _base)) {}
+    Plane3d(const Plane3d &p) : base(p.base), normal(p.normal), d(p.d) {}
 
     // operators
     Plane3d& operator=(const Plane3d &p);
 
     // others
-    double get_equation_coefficient_d() const;
     double get_signed_distance_from_point_to_plane(const Vector3d &v) const;
-    bool handle_intersection_of_segment_with_plane(Segment3d &s) const;
-    sf::Vertex get_projection_on_plane(const Vector3d &v, const unsigned window_width, const unsigned window_height) const;
+    bool handle_intersection_of_segment_with_plane(Vector3d &a, Vector3d &b) const;
+    sf::Vertex get_projection_on_plane(const Vector3d &v,
+                                       const unsigned window_width,
+                                       const unsigned window_height) const;
 };
 
 #endif

--- a/src/geometry/segment3d.cpp
+++ b/src/geometry/segment3d.cpp
@@ -6,16 +6,9 @@
 
 Segment3d& Segment3d::operator=(const Segment3d &s) {
     if (this != &s) {
-        a = s.a;
-        b = s.b;
+        i = s.i;
+        j = s.j;
     }
-
-    return *this;
-}
-
-Segment3d Segment3d::operator+=(const Vector3d &v) {
-    a += v;
-    b += v;
 
     return *this;
 }

--- a/src/geometry/segment3d.hpp
+++ b/src/geometry/segment3d.hpp
@@ -6,18 +6,20 @@
 
 class Segment3d {
 private:
-    Vector3d a, b;
-
+    size_t i, j;
+    
 public:
     // constructors
-    Segment3d() : a(Vector3d()), b(Vector3d()) {}
-    Segment3d(const Vector3d &_a, const Vector3d &_b) : a(_a), b(_b) {}
-    Segment3d(const Vector3d &_a, const Vector3d &_b, const sf::Color _color) : a(_a, _color), b(_b, _color) {}
-    Segment3d(const Segment3d &s) : a(s.a), b(s.b) {}
+    Segment3d() : i(0), j(0) {}
+    Segment3d(const size_t _i, const size_t _j) : i(_i), j(_j) {}
+    Segment3d(const Segment3d &s) : i(s.i), j(s.j) {}
 
     // operators
     Segment3d& operator=(const Segment3d &s);
-    Segment3d operator+=(const Vector3d &v);
+
+    // others
+    Vector3d& get_a(std::vector<Vector3d> &points) const { return points[i]; }
+    Vector3d& get_b(std::vector<Vector3d> &points) const { return points[j]; }
 
 
 friend class Plane3d;

--- a/src/geometry/solid3d.cpp
+++ b/src/geometry/solid3d.cpp
@@ -4,27 +4,24 @@
 // ### operators ################################
 // ##############################################
 
-Solid3d Solid3d::operator+=(const Solid3d &solid) {
-    for (auto s : solid.edges)
-        this -> add_segment(s);
+// Solid3d Solid3d::operator+=(const Solid3d &solid) {
+//     for (auto s : solid.edges)
+//         this -> add_segment(s);
 
-    return *this;
-}
+//     return *this;
+// }
 
 Solid3d Solid3d::operator+(const Vector3d &v) const {
     Solid3d new_solid(*this);
 
-    for (auto &s : new_solid.edges)
-        s += v;
-
-    new_solid.center += v;
+    new_solid += v;
 
     return new_solid;
 }
 
 Solid3d Solid3d::operator+=(const Vector3d &v) {
-    for (auto &s : edges)
-        s += v;
+    for (auto &p : points)
+        p += v;
 
     center += v;
 
@@ -37,49 +34,74 @@ Solid3d Solid3d::operator+=(const Vector3d &v) {
 // ##############################################
 
 void Solid3d::get_max_size() {
-    for (auto s : edges)
-        max_size = std::max({max_size, (s.a - center).norm(), (s.b - center).norm()});
+    for (auto p : points)
+        max_size = std::max({max_size, (p - center).norm()});
 }
 
 // #TODO: missing comment
-void Solid3d::render_solid(sf::RenderWindow &window, const unsigned window_width, const unsigned window_height, const Camera3d &camera) {
-
-    // check if center is too far from frustrum
-    if (max_size >= 0) {
-        for (auto side : camera.frustrum) {
-            const Vector3d temp_center = camera.transform_vector(center);
-            if (side.get_signed_distance_from_point_to_plane(temp_center) <= - max_size)
-                return;
-        }
-    }
+void Solid3d::render_solid(sf::RenderWindow &window,
+                           const unsigned window_width,
+                           const unsigned window_height,
+                           const Camera3d &camera) {
 
     figure.clear();
 
-    for (auto s : edges) {
-        bool outside_frustrum = false;
-        s = camera.transform_segment(s);
+    bool inside_frustrum = true;
+
+    // check if center is too far from frustrum
+    if (max_size >= 0) {
+        const Vector3d temp_center = camera.transform_vector(center);
 
         for (auto side : camera.frustrum) {
-            outside_frustrum = side.handle_intersection_of_segment_with_plane(s);
-            if (outside_frustrum)
+            double d = side.get_signed_distance_from_point_to_plane(temp_center);
+
+            // further than max_size in the opposite direction from one frustrum plane
+            if (d <= - max_size)
+                return;
+            // within every frustrum plane in the good direction by at least max_size
+            else if (d <= max_size) {
+                inside_frustrum = false;
                 break;
+            }
+        }
+    }
+
+
+    std::vector<Vector3d> points_tr(points);
+    for (auto &p : points_tr)
+        p = camera.transform_vector(p);
+
+    for (auto s : edges) {
+        bool outside_frustrum = false;
+
+        if (! inside_frustrum) {
+            for (auto side : camera.frustrum) {
+                outside_frustrum = side.handle_intersection_of_segment_with_plane(s.get_a(points_tr),
+                                                                                  s.get_b(points_tr));
+                if (outside_frustrum)
+                    break;
+            }
         }
 
         if (! outside_frustrum) {
-            figure.append(camera.frustrum[0].get_projection_on_plane(s.a, window_width, window_height));
-            figure.append(camera.frustrum[0].get_projection_on_plane(s.b, window_width, window_height));
+            figure.append(camera.frustrum[0].get_projection_on_plane(s.get_a(points_tr),
+                                                                     window_width,
+                                                                     window_height));
+            figure.append(camera.frustrum[0].get_projection_on_plane(s.get_b(points_tr),
+                                                                     window_width, 
+                                                                     window_height));
         }
     }
 
     window.draw(figure);
 }
 
-void Solid3d::rotate_around_vector(const Vector3d rotation_center, const Vector3d &axis, const double theta) {
+void Solid3d::rotate_around_vector(const Vector3d rotation_center,
+                                   const Vector3d &axis,
+                                   const double theta) {
     
-    for (auto &s : edges) {
-        s.a.rotate(rotation_center, axis, theta);
-        s.b.rotate(rotation_center, axis, theta);
-    }
+    for (auto &p : points)
+        p.rotate(rotation_center, axis, theta);
 
     center.rotate(rotation_center, axis, theta);
 }

--- a/src/geometry/solid3d.hpp
+++ b/src/geometry/solid3d.hpp
@@ -8,13 +8,11 @@
 #include "camera3d.hpp"
 
 class Solid3d {
-public:
-    enum class SOLID_TYPE {CUBE, SPHERE};
-
 private:
     sf::VertexArray figure;
 
 protected:
+    std::vector<Vector3d> points;
     std::vector<Segment3d> edges;
     Vector3d center;
     double max_size = -1.0;
@@ -24,17 +22,22 @@ public:
     Solid3d() { figure.setPrimitiveType(sf::Lines); }
 
     // operators
-    Solid3d operator+=(const Solid3d &solid);
+    // Solid3d operator+=(const Solid3d &solid);
     Solid3d operator+(const Vector3d &v) const;
     Solid3d operator+=(const Vector3d &v);
 
     // others
     void set_max_size(const double _max_size) { max_size = _max_size; }
     void get_max_size();
-    void add_segment(const Segment3d &s) { edges.push_back(s); }
-    void render_solid(sf::RenderWindow &window, const unsigned window_width, const unsigned window_height, const Camera3d &camera);
-    void clear() { edges.clear(); }
-    void rotate_around_vector(const Vector3d rotation_center, const Vector3d &axis, const double theta);
+    void add_point(const Vector3d &v) { points.push_back(v); }
+    void add_segment(const size_t i, const size_t j) { edges.push_back(Segment3d(i, j)); }
+    void render_solid(sf::RenderWindow &window,
+                      const unsigned window_width,
+                      const unsigned window_height,
+                      const Camera3d &camera);
+    void rotate_around_vector(const Vector3d rotation_center,
+                              const Vector3d &axis,
+                              const double theta);
     void rotate(const Vector3d &axis, const double theta);
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,7 @@ int main()
     sf::Clock loop_timer;
     sf::Clock current_time;
 
-	srand(time(NULL));
+	srand(time(nullptr));
 
 
     // setup window
@@ -57,15 +57,15 @@ int main()
         camera.rotate(Mouse::get_move_x(window), Mouse::get_move_y(window));
 
         // move camera
-        if(sf::Keyboard::isKeyPressed(sf::Keyboard::W))
+        if(sf::Keyboard::isKeyPressed(sf::Keyboard::Z))
             camera.move(Camera3d::DIRECTION::FRONT);
         if(sf::Keyboard::isKeyPressed(sf::Keyboard::S))
             camera.move(Camera3d::DIRECTION::BACK);
         if(sf::Keyboard::isKeyPressed(sf::Keyboard::D))
             camera.move(Camera3d::DIRECTION::RIGHT);
-        if(sf::Keyboard::isKeyPressed(sf::Keyboard::A))
-            camera.move(Camera3d::DIRECTION::LEFT);
         if(sf::Keyboard::isKeyPressed(sf::Keyboard::Q))
+            camera.move(Camera3d::DIRECTION::LEFT);
+        if(sf::Keyboard::isKeyPressed(sf::Keyboard::A))
             camera.move(Camera3d::DIRECTION::UP);
         if(sf::Keyboard::isKeyPressed(sf::Keyboard::E))
             camera.move(Camera3d::DIRECTION::DOWN);
@@ -75,12 +75,6 @@ int main()
 
         field.move_objects();
         field.render_objects(window, Parameters::window_width, Parameters::window_height, camera);
-
-
-        //ast.rotate_around_vector(Vector3d(0, 0, 0), Vector3d(0, 1, 0), 1);
-        //ast.rotate(Vector3d(0, 1, 1), 3);
-        // for (auto ast : asts)
-        //     ast.render_solid(window, Parameters::window_width, Parameters::window_height, camera);
 
         window.display();
 

--- a/src/utils/parameters.hpp
+++ b/src/utils/parameters.hpp
@@ -4,8 +4,8 @@
 #include <iomanip> // for std::setprecision
 #include "looptimer.hpp"
 
-#define INITIAL_WINDOW_WIDTH  1900
-#define INITIAL_WINDOW_HEIGHT 1200
+#define INITIAL_WINDOW_WIDTH  1200
+#define INITIAL_WINDOW_HEIGHT 700
 
 #define FPS 60
 #define MAX_MAIN_LOOP_DURATION (1000.0 / FPS)

--- a/todo.md
+++ b/todo.md
@@ -1,14 +1,15 @@
 # todo list
 
-| emoji       | meaning                      |
-| :---------: | :--------------------------- |
-| :sos:       | critical bug                 |
-| :warning:   | bug                          |
-| :eyes:      | to check                     |
-| :flashlight:| simplification/clarification |
-| :clipboard: | comment                      |
-| :sparkles:  | typos and style              |
-| :tada:      | new feature                  |
+| emoji        | meaning                      | code           |
+| :----------: | :--------------------------- | :------------- |
+| :sos:        | critical bug                 | `:sos:`        |
+| :warning:    | bug                          | `:warning:`    |
+| :eyes:       | to check                     | `:eyes:`       |
+| :flashlight: | simplification/clarification | `:flashlight:` |
+| :clipboard:  | comment                      | `:clipboard:`  |
+| :sparkles:   | typos & style                | `:sparkles:`   |
+| :tada:       | new feature                  | `:tada:`       |
+| :cloud:      | minor modification           | `:cloud:`      |
 
 
 ### General

--- a/todo.md
+++ b/todo.md
@@ -19,6 +19,7 @@
 - [ ] :tada: setup matrix and vector multiplication and write every formula under a matrix form
 - [ ] :tada: write test for every class
 - [ ] :tada: add `constexpr` keyword
+- [ ] :sparkles: edit old commit messages to match emoji commit code table
 
 * `src/main.cpp`
     - [ ] :eyes: check all

--- a/todo.md
+++ b/todo.md
@@ -44,10 +44,11 @@
 
 * `Vector3d`
     - [x] :eyes: check friend declarations
+    - [ ] :tada: pre-compute every rotation cos/sin
 
 * `Segment3d`
     - [x] :eyes: check friend declarations
-    - [ ] :tada: references to Vector3d rather than holding objects
+    - [x] :tada: references to Vector3d rather than holding objects
 
 * `Plane3d`
     - [x] :eyes: check friend declarations
@@ -59,11 +60,12 @@
     - [x] :tada: remove `SOLID_TYPE` enum and constructor and create custom cube, sphere and other solid classes
     - [x] :tada: add `max_size` object handling and improve rendering performances
     - [ ] :tada: make vector of Vector3d rather than holding Vector3d in Segment3d
-    - [ ] :tada: precompute rotation cos and sin
+    - [ ] :eyes: check if intersection with window is perfect
 
 * `Camera3d`
     - [x] :eyes: check every `// other` methods
     - [x] :eyes: check constructor
+    - [ ] :tada: pre-compute cos/sin of theta_x/y/z
 
 * `geometry.*`
     - [x] :warning: pole point of the sphere repeated
@@ -86,5 +88,3 @@
 * `Solid3d`
     - [ ] :clipboard: in `rotate_around_vector()` don't pass `rotation_center` by reference: explain why
     - [ ] :clipboard: necessary to specify `max_size` to improve rendering performances
-
-


### PR DESCRIPTION
New implementation of the `Segment3d` and `Solid3d` classes:
- Before a `Segment3d` was holding two `Vector3d` objects and a `Solid3d` was mainly defined as a `std::vector<Segment3d>`. So a point connecting two segments was repeated in both `Segment3d` objects.
- Now, a `Solid3d` is mainly defined as a `std::vector<Vector3d>`, a points cloud in space, and a `Segment3d` only holds the index of two points in this last vector. So a `Solid3d` is defined as a graph in mathematics would be defined: a set of vertex and a set of edges, each edge being a link between two vertices. This allows a huge performance improvement as the calculus are made only once for each point of the `std::vector<Vector3d>` points cloud, and not repeated for each segment as before.

The classes `Plane3d`, `Camera3d` and all the geometric objects in `geometry.hpp/cpp` have been redefined accordingly.